### PR TITLE
Fix jar publication. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'uk.me.jeremygreen'
-version = '0.0.1-SNAPSHOT'
+version = '1.0'
 sourceCompatibility = '17'
 
 repositories {
@@ -36,11 +36,8 @@ springBoot {
 
 publishing {
     publications {
-        maven(MavenPublication) {
-            groupId = 'uk.me.jeremygreen.springexperiments'
-            artifactId = 'springexperiments'
-            version = '1.0'
-            from components.java
+        bootJava(MavenPublication) {
+            artifact bootJar
         }
     }
     repositories {


### PR DESCRIPTION
Was publishing a jar without a manifest or dependencies. https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/gradle-plugin/reference/html/#publishing-your-application-maven-publish. Changing from snapshot to release means get stable artifact version.