### PR TITLE
Configure shadowJar, for AWS lambda.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ When run in development mode, requests to port 3000 that aren't handled by React
 
 ## Release Build Instructions
 
-Build using:
+Build using one of:
 
 ```
-./gradlew shadowJar
+./gradlew bootJar # to run locally
+./gradlew shadowJar # for AWS lambda
 ```
 
 The React app will be built and bundled into the jar.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When run in development mode, requests to port 3000 that aren't handled by React
 Build using:
 
 ```
-./gradlew bootJar
+./gradlew shadowJar
 ```
 
 The React app will be built and bundled into the jar.

--- a/TODO
+++ b/TODO
@@ -11,6 +11,9 @@
   - https://github.com/reactjs/react.dev/pull/5487#issuecomment-1409720741
   - https://github.com/facebook/create-react-app/issues/13072
 
+* Should be able to use shadowJar in place of bootJar
+  - shadowJar is lacking most manifest attributes so isn't executable.
+
 * A release branch, so can fix problems without breaking aws-experiments deployment?
   - or single branch and versioned publishing
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ shadowJar {
 publishing {
     // https://imperceptiblethoughts.com/shadow/publishing/#publishing-with-maven-publish-plugin
     publications {
+        bootJava(MavenPublication) {
+            artifact bootJar
+        }
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ plugins {
     //
     // https://docs.spring.io/spring-cloud-function/docs/current/reference/html/aws-intro.html#_notes_on_jar_layout
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'org.springframework.boot.experimental.thin-launcher' version "1.0.31.RELEASE"
     id 'maven-publish'
     id 'java'
 }
@@ -41,12 +40,9 @@ springBoot {
     mainClass = 'uk.me.jeremygreen.springexperiments.SpringExperimentsApplication'
 }
 
-assemble.dependsOn = [thinJar, shadowJar]
+assemble.dependsOn = [bootJar, shadowJar]
 import com.github.jengelman.gradle.plugins.shadow.transformers.*
 shadowJar {
-    manifest {
-      inheritFrom(project.tasks.thinJar.manifest)
-    }
 	archiveClassifier = 'aws'
     from("${project('src:frontend').projectDir}/build") {
         into("public")
@@ -67,7 +63,6 @@ shadowJar {
 		mergeStrategy = "append"
 	}
 }
-shadowJar.mustRunAfter thinJar
 
 publishing {
     // https://imperceptiblethoughts.com/shadow/publishing/#publishing-with-maven-publish-plugin

--- a/build.gradle
+++ b/build.gradle
@@ -43,25 +43,25 @@ springBoot {
 assemble.dependsOn = [bootJar, shadowJar]
 import com.github.jengelman.gradle.plugins.shadow.transformers.*
 shadowJar {
-	archiveClassifier = 'aws'
+    archiveClassifier = 'aws'
     from("${project('src:frontend').projectDir}/build") {
         into("public")
     }
-	// dependencies {
-	// 	exclude(
-	// 		dependency("org.springframework.cloud:spring-cloud-function-web:${springCloudFunctionVersion}"))
-	// }
-	// Required for Spring
-	mergeServiceFiles()
-	append 'META-INF/spring.handlers'
-	append 'META-INF/spring.schemas'
-	append 'META-INF/spring.tooling'
-	append 'META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports'
-	append 'META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports'
-	transform(PropertiesFileTransformer) {
-		paths = ['META-INF/spring.factories']
-		mergeStrategy = "append"
-	}
+    // dependencies {
+    // 	exclude(
+    // 		dependency("org.springframework.cloud:spring-cloud-function-web:${springCloudFunctionVersion}"))
+    // }
+    // Required for Spring
+    mergeServiceFiles()
+    append 'META-INF/spring.handlers'
+    append 'META-INF/spring.schemas'
+    append 'META-INF/spring.tooling'
+    append 'META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports'
+    append 'META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports'
+    transform(PropertiesFileTransformer) {
+        paths = ['META-INF/spring.factories']
+        mergeStrategy = "append"
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,12 @@ plugins {
     id 'org.springframework.boot' version "${SPRING_BOOT_VERSION}"
     // https://plugins.gradle.org/plugin/io.spring.dependency-management
     id 'io.spring.dependency-management' version '1.1.4'
+    // Need to using a shaded jar (shadowJar) since a spring executable jar doesn't work
+    // with AWS lambda:
+    //
+    // https://docs.spring.io/spring-cloud-function/docs/current/reference/html/aws-intro.html#_notes_on_jar_layout
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'org.springframework.boot.experimental.thin-launcher' version "1.0.31.RELEASE"
     id 'maven-publish'
     id 'java'
 }
@@ -24,6 +30,7 @@ repositories {
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:${SPRING_BOOT_VERSION}"
     implementation "com.amazonaws.serverless:aws-serverless-java-container-springboot3:2.0.0-M2"
+    implementation("org.springframework.cloud:spring-cloud-function-adapter-aws:4.1.0")
     runtimeOnly "org.springframework.boot:spring-boot-devtools:${SPRING_BOOT_VERSION}"
     annotationProcessor "org.springframework:spring-context-indexer:6.1.1"
     testImplementation "org.springframework.boot:spring-boot-starter-test:${SPRING_BOOT_VERSION}"
@@ -34,10 +41,39 @@ springBoot {
     mainClass = 'uk.me.jeremygreen.springexperiments.SpringExperimentsApplication'
 }
 
+assemble.dependsOn = [thinJar, shadowJar]
+import com.github.jengelman.gradle.plugins.shadow.transformers.*
+shadowJar {
+    manifest {
+      inheritFrom(project.tasks.thinJar.manifest)
+    }
+	archiveClassifier = 'aws'
+    from("${project('src:frontend').projectDir}/build") {
+        into("public")
+    }
+	// dependencies {
+	// 	exclude(
+	// 		dependency("org.springframework.cloud:spring-cloud-function-web:${springCloudFunctionVersion}"))
+	// }
+	// Required for Spring
+	mergeServiceFiles()
+	append 'META-INF/spring.handlers'
+	append 'META-INF/spring.schemas'
+	append 'META-INF/spring.tooling'
+	append 'META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports'
+	append 'META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports'
+	transform(PropertiesFileTransformer) {
+		paths = ['META-INF/spring.factories']
+		mergeStrategy = "append"
+	}
+}
+shadowJar.mustRunAfter thinJar
+
 publishing {
+    // https://imperceptiblethoughts.com/shadow/publishing/#publishing-with-maven-publish-plugin
     publications {
-        bootJava(MavenPublication) {
-            artifact bootJar
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
         }
     }
     repositories {
@@ -61,11 +97,6 @@ if (hasProperty('buildScan')) {
 }
 
 // Add React frontend artifacts to the jar.
-bootJar.dependsOn('src:frontend:npm_run_build')
-bootJar {
-    from("${project('src:frontend').projectDir}/build") {
-	into("public")
-    }
-}
+shadowJar.dependsOn('src:frontend:npm_run_build')
 
 test.dependsOn('src:frontend:npm_run_ci')

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     // with AWS lambda:
     //
     // https://docs.spring.io/spring-cloud-function/docs/current/reference/html/aws-intro.html#_notes_on_jar_layout
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.github.johnrengelman.shadow' version '8.1.0'
     id 'maven-publish'
     id 'java'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -103,5 +103,4 @@ bootJar {
     }
 }
 
-
 test.dependsOn('src:frontend:npm_run_ci')

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,14 @@ if (hasProperty('buildScan')) {
     }
 }
 
-// Add React frontend artifacts to the jar.
+// Add React frontend artifacts to the jars.
 shadowJar.dependsOn('src:frontend:npm_run_build')
+bootJar.dependsOn('src:frontend:npm_run_build')
+bootJar {
+    from("${project('src:frontend').projectDir}/build") {
+        into("public")
+    }
+}
+
 
 test.dependsOn('src:frontend:npm_run_ci')

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,9 @@ if (hasProperty('buildScan')) {
 }
 
 // Add React frontend artifacts to the jars.
-shadowJar.dependsOn('src:frontend:npm_run_build')
-bootJar.dependsOn('src:frontend:npm_run_build')
+[shadowJar, bootJar].each { jar ->
+    jar.dependsOn('src:frontend:npm_run_build')
+}
 bootJar {
     from("${project('src:frontend').projectDir}/build") {
         into("public")

--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,11 @@ shadowJar {
 }
 
 publishing {
-    // https://imperceptiblethoughts.com/shadow/publishing/#publishing-with-maven-publish-plugin
     publications {
         bootJava(MavenPublication) {
             artifact bootJar
         }
+        // https://imperceptiblethoughts.com/shadow/publishing/#publishing-with-maven-publish-plugin
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
         }


### PR DESCRIPTION
Spring boot jars are in an "executable" format, with classes inside a non-standard BOOT-INF directory inside the jar. This doesn't work with AWS lambda which expects a normal jar. The solution is to use this gradle plugin:

https://imperceptiblethoughts.com/shadow/introduction/
https://docs.spring.io/spring-cloud-function/docs/current/reference/html/aws-intro.html

It should be possible to use the shadowJar in place of the executable jar, but there seems to be a bug in the plugin (or I'm using it wrong), so this PR retains the bootJar jars, sending both types of jar to the S3 maven repo. The shadow jars have an -aws suffix.

Had to use 8.1.0 not 8.1.1 plugin to avoid bug (see TODO) that meant jar didn't have -aws suffix.