### PR TITLE
jars missing react artifacts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,10 +28,19 @@ jobs:
 
     - name: assemble
       run: ./gradlew --scan assemble
+
+    # Store as artifacts for debugging.
+    - name: archive jars
+      uses: actions/upload-artifact@v4
+      with:
+        name: jars
+        path: |
+          build/libs/*.jar
     
     - name: check
       run: ./gradlew --scan check
 
+    # Publish to S3 for deployment
     - name: publish
       if: ${{ github.ref == 'refs/heads/master' }}
       run: ./gradlew --scan publish

--- a/TODO
+++ b/TODO
@@ -1,3 +1,5 @@
+* Cypress tests or similar for jars.
+
 * Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
 
 * Try out redux-toolkit.
@@ -86,8 +88,6 @@
 * Localization.
 
 * jest snapshot tests.
-
-* Automated browser tests.
 
 * Actuator logging?
   - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html

--- a/TODO
+++ b/TODO
@@ -1,3 +1,11 @@
+* Deployed app not working
+  - redux app not present/accessible, but spring is.
+  - bootJar build works locally
+  - https://s3.console.aws.amazon.com/s3/object/aws-experiments?region=eu-west-1&bucketType=general&prefix=artifacts/uk/me/jeremygreen/spring-experiments/1.0/spring-experiments-1.0.jar does not
+  - local jar from assemble task works
+
+* Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
+
 * Try out redux-toolkit.
 
 * Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
@@ -5,8 +13,6 @@
 * Cache npm files on github actions.
 
 * Enable branch protection rule for master.
-
-* No cancellation of requests in fetchLocalAuthoritiesJson().
 
 * Split gradle checks into multiple github actions steps?
 

--- a/TODO
+++ b/TODO
@@ -1,9 +1,3 @@
-* Deployed app not working
-  - redux app not present/accessible, but spring is.
-  - bootJar build works locally
-  - https://s3.console.aws.amazon.com/s3/object/aws-experiments?region=eu-west-1&bucketType=general&prefix=artifacts/uk/me/jeremygreen/spring-experiments/1.0/spring-experiments-1.0.jar does not
-  - local jar from assemble task works
-
 * Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
 
 * Try out redux-toolkit.

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ assemble.dependsOn = [bootJar, shadowJar]
 import com.github.jengelman.gradle.plugins.shadow.transformers.*
 shadowJar {
     archiveClassifier = 'aws'
-    from("${project('src:frontend').projectDir}/build") {
+    from("${project('src:frontend').projectDir}/dist") {
         into("public")
     }
     // dependencies {
@@ -99,7 +99,7 @@ if (hasProperty('buildScan')) {
     jar.dependsOn('src:frontend:npm_run_build')
 }
 bootJar {
-    from("${project('src:frontend').projectDir}/build") {
+    from("${project('src:frontend').projectDir}/dist") {
         into("public")
     }
 }

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -10,8 +10,5 @@ npm-debug.log
 # jest
 coverage
 
-# react
-build
-
 # vite
 /dist


### PR DESCRIPTION
Changing from create react app to vite moved react artifacts from src/frontend/build/ to src/frontend/dist/, but build.gradle wasn't updated to account for this. Builds worked locally since build/ was still present.