### PR TITLE
Upgrade GitHub action versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,29 +9,29 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.1
     
     - name: JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4.0.0
       with:
         java-version: '17'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version-file: '.node-version'
 
     - name: setup gradle
-      uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+      uses: gradle/gradle-build-action@3.0.0
 
     - name: assemble
       run: ./gradlew --scan assemble
 
     # Store as artifacts for debugging.
     - name: archive jars
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.0
       with:
         name: jars
         path: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
         node-version-file: '.node-version'
 
     - name: setup gradle
-      uses: gradle/gradle-build-action@3.0.0
+      uses: gradle/actions/setup-gradle@v3
 
     - name: assemble
       run: ./gradlew --scan assemble

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
-* Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
-
 * Try out redux-toolkit.
 
 * More cypress tests.


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-java@v3, gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
