### PR TITLE
Configure python on CI too

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,8 +23,15 @@ jobs:
       with:
         node-version-file: '.node-version'
 
+    - uses: actions/setup-python@v5.0.0
+      with:
+        cache: 'pip'
+
     - name: setup gradle
       uses: gradle/actions/setup-gradle@v3
+
+    - name: local bin/setup script
+      run: ./bin/setup
 
     - name: assemble
       run: ./gradlew --scan assemble

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .gradle
 /build/
 !gradle/wrapper/gradle-wrapper.jar
-bin
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -22,11 +22,8 @@ Configure python venv:
 ```
 sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev curl libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
-eval "$(~/.pyenv/bin/pyenv init -)"
-~/.pyenv/bin/pyenv install
-pyenv exec python -m venv --clear .venv
-. environment
-pip install -r requirements.txt
+bin/setup
+. ./environment
 ```
 
 To build and run the Spring Boot server from the command line:

--- a/TODO
+++ b/TODO
@@ -6,11 +6,6 @@
     - this explains how to use SAM with gradle build
       - https://aws.amazon.com/blogs/compute/building-serverless-java-applications-with-the-aws-sam-cli/
 
-* On CI:
-
-environment: line 24: pyenv: command not found
-venv activate script missing - README.md explains how to set up your python environment.
-
 * Try out redux-toolkit.
 
 * More cypress tests.

--- a/bin/.common.sh
+++ b/bin/.common.sh
@@ -1,0 +1,23 @@
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+backtrace() {
+    local err="$?"
+    set +x
+    printf "%s\n\n" "*********************************************************************"
+    printf "ERROR: %s:%i exited with code: %s\n\n" "${BASH_SOURCE[0]}" "${BASH_LINENO[0]}" "${err}"
+    printf "%s\n\n" "${BASH_COMMAND:-}"
+    for (( i = 0 ; i < ${#FUNCNAME[@]} - 1 ; i++ )) ; do
+	printf "%-50s  %s:%i\n" "${FUNCNAME[$i+1]}()" "${BASH_SOURCE[$i+1]}" "${BASH_LINENO[$i]}"
+    done
+    exit "${err}"
+}
+trap 'backtrace' ERR
+
+log() {
+    printf "[%s %s] %s\n" \
+           "$(date '+%Y-%m-%d %H:%M:%S' --utc)" \
+           "$(basename -- "$0")" \
+           "$*"
+}

--- a/bin/setup
+++ b/bin/setup
@@ -25,10 +25,7 @@ elif which pyenv > /dev/null 2> /dev/null ; then
     eval "$(pyenv init -)"
 else
 	cat <<EOF
-You need to:
-
-* Install pyenv: https://github.com/pyenv/pyenv#installation
-* Install python-build as an pyenv plugin: https://github.com/pyenv/python-build#installation
+Install pyenv: https://github.com/pyenv/pyenv#installation
 
 ...and re-run this script.
 

--- a/bin/setup
+++ b/bin/setup
@@ -42,7 +42,7 @@ if [ "${pythonVersonExpected}" != "${pythonVersonActual}" ] ; then
 fi
 
 # pip
-pyenv exec python -m venv --clear .venv
+python -m venv --clear .venv
 pip install -r requirements.txt
 
 # TODO nodenv

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019-2021 Jeremy Green.
+# Copyright (c) 2019-2024 Jeremy Green.
 
 set -o errexit
 set -o nounset

--- a/bin/setup
+++ b/bin/setup
@@ -16,7 +16,7 @@ pythonVersonExpected="$(cat "${SOURCE_DIR}/.python-version")"
 if [ -n "${GITHUB_ACTIONS:-}" ] ; then
     # python configured with actions/setup-python
     true
-elif command -v pyenv > /dev/null 2> /dev/null ; then
+elif which pyenv > /dev/null 2> /dev/null ; then
     log "installing python ${pythonVersonExpected}"
     pyenv install "${pythonVersonExpected}" \
 	  --skip-existing \

--- a/bin/setup
+++ b/bin/setup
@@ -42,7 +42,11 @@ if [ "${pythonVersonExpected}" != "${pythonVersonActual}" ] ; then
 fi
 
 # pip
+log "clearing python venv"
 python -m venv --clear .venv
+log "pip install"
 pip install -r requirements.txt
 
 # TODO nodenv
+
+log "done"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2021 Jeremy Green.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+# shellcheck source=./common.sh
+source "$(dirname "$0")/.common.sh"
+SOURCE_DIR="$(dirname "$0")/.."
+
+# python
+pythonVersonExpected="$(cat "${SOURCE_DIR}/.python-version")"
+if [ -n "${GITHUB_ACTIONS:-}" ] ; then
+    # python configured with actions/setup-python
+    true
+elif command -v pyenv > /dev/null 2> /dev/null ; then
+    log "installing python ${pythonVersonExpected}"
+    pyenv install "${pythonVersonExpected}" \
+	  --skip-existing \
+	  --verbose
+    PATH="${HOME}/.pyenv/bin:${PATH}"
+    eval "$(pyenv init -)"
+else
+	cat <<EOF
+You need to:
+
+* Install pyenv: https://github.com/pyenv/pyenv#installation
+* Install python-build as an pyenv plugin: https://github.com/pyenv/python-build#installation
+
+...and re-run this script.
+
+EOF
+	exit 1
+fi
+pythonVersonActual="$(python -V | awk '{ print $2 }')"
+if [ "${pythonVersonExpected}" != "${pythonVersonActual}" ] ; then
+    log "ERROR: need python ${pythonVersonExpected} but have python ${pythonVersonActual}"
+    exit 1
+fi
+
+# pip
+pyenv exec python -m venv --clear .venv
+pip install -r requirements.txt
+
+# TODO nodenv

--- a/environment
+++ b/environment
@@ -1,6 +1,6 @@
 # -*- mode: shell-script -*-
 #
-# Copyright (c) 2019-2023 Jeremy Green.
+# Copyright (c) 2019-2024 Jeremy Green.
 
 SOURCE_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 

--- a/environment
+++ b/environment
@@ -21,7 +21,9 @@ PATH="${SOURCE_DIR}/src/frontend/node_modules/.bin:${PATH}"
 if [ -d "${HOME}/.pyenv/bin" ] ; then
     PATH="${HOME}/.pyenv/bin:${PATH}"
 fi
-eval "$(pyenv init -)"
+if which pyenv > /dev/null 2> /dev/null ; then
+    eval "$(pyenv init -)"
+fi
 if [ -e "${SOURCE_DIR}/.venv/bin/activate" ] ; then
     VIRTUAL_ENV_DISABLE_PROMPT=true source "${SOURCE_DIR}/.venv/bin/activate"
 else

--- a/environment
+++ b/environment
@@ -18,11 +18,13 @@ fi
 PATH="${SOURCE_DIR}/src/frontend/node_modules/.bin:${PATH}"
 
 # python
-if [ -d "${HOME}/.pyenv/bin" ] ; then
-    PATH="${HOME}/.pyenv/bin:${PATH}"
-fi
-if which pyenv > /dev/null 2> /dev/null ; then
-    eval "$(pyenv init -)"
+if [ -z "${GITHUB_ACTIONS:-}"] ; then
+    if [ -d "${HOME}/.pyenv/bin" ] ; then
+        PATH="${HOME}/.pyenv/bin:${PATH}"
+    fi
+    if which pyenv > /dev/null 2> /dev/null ; then
+        eval "$(pyenv init -)"
+    fi
 fi
 if [ -e "${SOURCE_DIR}/.venv/bin/activate" ] ; then
     VIRTUAL_ENV_DISABLE_PROMPT=true source "${SOURCE_DIR}/.venv/bin/activate"


### PR DESCRIPTION
Avoids warning when sourcing `environment` when running cypress. Will allow use of `sam local start-api` on CI too...