### PR TITLE
Retries and debouncing

### DIFF
--- a/TODO
+++ b/TODO
@@ -56,6 +56,10 @@
 
 * More method/class javadoc.
 
+* RenderWithStore component would be better as a function.
+  - less verbose
+  - could return extra objects, e.g. the store.
+
 * Test FsaService json parsing using file:/// URLs.
 
 * Unit tests for lambda (in addition to cypress end-to-end tests).

--- a/TODO
+++ b/TODO
@@ -1,7 +1,4 @@
 * Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
-  X retries
-  X https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
-  X debounce too, to reduce server load.
   - unit test
     - https://mswjs.io/docs/api/http#once?
     - https://mswjs.io/docs/recipes/polling/?

--- a/TODO
+++ b/TODO
@@ -23,6 +23,8 @@
 
 * Sentry.
 
+* Check for carets in package.json in unit tests.
+
 * Add pip constraints file.
 
 * 0% rows generally have non-zero bar graph size

--- a/TODO
+++ b/TODO
@@ -1,7 +1,8 @@
 * Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
-  - https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
+  X retries
+  X https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
+  X debounce too, to reduce server load.
   - https://mswjs.io/docs/api/http#once should allow this to be tested?
-  - debounce too, to reduce server load.
 
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library

--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-* Saving gradle report on CI is no working either
+* Saving gradle report on CI is not working
   - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
   - step skipped if earlier steps fail.
 

--- a/TODO
+++ b/TODO
@@ -26,6 +26,8 @@
   - https://github.com/xnimorz/use-debounce
   - https://github.com/jg210/spring-experiments/pull/41/commits/ab055f1dbdfa7a9b00c04c1d01cb7b153121bf7f was my workaround.
 
+* Reduce RTK Query retry interval in unit tests?
+
 * Check for carets in package.json in unit tests.
 
 * Add pip constraints file.

--- a/TODO
+++ b/TODO
@@ -1,3 +1,8 @@
+* Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
+  - https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
+  - https://mswjs.io/docs/api/http#once should allow this to be tested?
+  - debounce too, to reduce server load.
+
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library
 
@@ -19,10 +24,6 @@
 * Sentry.
 
 * Add pip constraints file.
-
-* Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
-  - https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
-  - https://mswjs.io/docs/api/http#once should allow this to be tested?
 
 * 0% rows generally have non-zero bar graph size
   - from rounding

--- a/TODO
+++ b/TODO
@@ -106,7 +106,8 @@
 
 * unit test changing Table localAuthorityId shows loading... state again 
 
-* Improved failed-connection handling.
+* Error page if run out of retries.
+  - or infinite retries and a network connectivity warning?
 
 * Verify json metadata in case get paged data.
   - check meta.totalPages is 1.

--- a/TODO
+++ b/TODO
@@ -2,7 +2,9 @@
   X retries
   X https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
   X debounce too, to reduce server load.
-  - https://mswjs.io/docs/api/http#once should allow this to be tested?
+  - unit test
+    - https://mswjs.io/docs/api/http#once?
+    - https://mswjs.io/docs/recipes/polling/?
 
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library

--- a/TODO
+++ b/TODO
@@ -6,9 +6,6 @@
 * Saving gradle report on CI is no working either
   - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
 
-* getRatingCounts unit test is flaky
-  - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
-
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library
 

--- a/TODO
+++ b/TODO
@@ -1,8 +1,6 @@
-* Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
-  - unit test for Establisments json too
-
 * Saving gradle report on CI is no working either
   - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
+  - step skipped if earlier steps fail.
 
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library
@@ -23,6 +21,10 @@
 * Analytics.
 
 * Sentry.
+
+* Bug report for use-debounce isPending().
+  - https://github.com/xnimorz/use-debounce
+  - https://github.com/jg210/spring-experiments/pull/41/commits/ab055f1dbdfa7a9b00c04c1d01cb7b153121bf7f was my workaround.
 
 * Check for carets in package.json in unit tests.
 

--- a/TODO
+++ b/TODO
@@ -1,7 +1,5 @@
 * Retries with exponential backoff for failed requests (e.g. from 429 from lambda rate limiting).
-  - unit test
-    - https://mswjs.io/docs/api/http#once?
-    - https://mswjs.io/docs/recipes/polling/?
+  - unit test for Establisments json too
 
 * Saving gradle report on CI is no working either
   - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836

--- a/TODO
+++ b/TODO
@@ -3,6 +3,12 @@
     - https://mswjs.io/docs/api/http#once?
     - https://mswjs.io/docs/recipes/polling/?
 
+* Saving gradle report on CI is no working either
+  - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
+
+* getRatingCounts unit test is flaky
+  - https://github.com/jg210/spring-experiments/actions/runs/7916661772/job/21610981836
+
 * Assert correct id selected in list in App.test.tsx.
   - https://cathalmacdonnacha.com/how-to-test-a-select-element-with-react-testing-library
 

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "18.2.0",
         "react-redux": "9.1.0",
         "typescript": "5.3.3",
+        "use-debounce": "10.0.0",
         "vite": "5.0.11",
         "vite-tsconfig-paths": "4.3.1"
       },
@@ -13304,6 +13305,17 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.0.tgz",
+      "integrity": "sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "18.2.0",
     "react-redux": "9.1.0",
     "typescript": "5.3.3",
+    "use-debounce": "10.0.0",
     "vite": "5.0.11",
     "vite-tsconfig-paths": "4.3.1"
   },

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -11,6 +11,8 @@ interface TableProps {
     localAuthorityId: number;
 }
 
+const DEBOUNCE_INTERVAL_MILLIS = 1000;
+
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
     // Scrolling through list of local authorities by holding down up or down
@@ -18,7 +20,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     // API requests.
     const [ localAuthorityIdDebounced ] = useDebounce(
         localAuthorityId,
-        1000,
+        DEBOUNCE_INTERVAL_MILLIS,
         { leading: true }
     );
     const { currentData } = useGetEstablishmentsQuery(localAuthorityIdDebounced, {

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -1,3 +1,4 @@
+import { useDebounce } from 'use-debounce';
 import {
     ratingsPercentages,
     RatingPercentage,
@@ -12,11 +13,19 @@ interface TableProps {
 
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
-    const { currentData } = useGetEstablishmentsQuery(localAuthorityId, {
+    // Scrolling through list of local authorities by holding down up or down
+    // arrow keys generates a lot of renders, so need to limit the number of
+    // API requests.
+    const [ localAuthorityIdDebounced,  debouncedState ] = useDebounce(
+        localAuthorityId,
+        1000,
+        { leading: true }
+    );
+    const { currentData } = useGetEstablishmentsQuery(localAuthorityIdDebounced, {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS
     });
-    if (currentData == undefined) {
+    if (currentData == undefined || debouncedState.isPending()) {
         return (
             <div data-testid="table_loading">loading...</div>
         );

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -16,7 +16,9 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     // Scrolling through list of local authorities by holding down up or down
     // arrow keys generates a lot of renders, so need to limit the number of
     // API requests.
-    const [ localAuthorityIdDebounced,  debouncedState ] = useDebounce(
+    //
+    // The isPending() returned by useDebounce doesn't work
+    const [ localAuthorityIdDebounced ] = useDebounce(
         localAuthorityId,
         1000,
         { leading: true }
@@ -25,7 +27,10 @@ export const Table = ({ localAuthorityId }: TableProps) => {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS
     });
-    if (currentData == undefined || debouncedState.isPending()) {
+    // The isPending() returned by useDebounce doesn't work if leading set to true,
+    // so compare prop and debounced value instead.
+    const debounced = localAuthorityId !== localAuthorityIdDebounced;
+    if (currentData == undefined || debounced) {
         return (
             <div data-testid="table_loading">loading...</div>
         );

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -16,8 +16,6 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     // Scrolling through list of local authorities by holding down up or down
     // arrow keys generates a lot of renders, so need to limit the number of
     // API requests.
-    //
-    // The isPending() returned by useDebounce doesn't work
     const [ localAuthorityIdDebounced ] = useDebounce(
         localAuthorityId,
         1000,

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -225,7 +225,7 @@ describe("App", () => {
     );
     const user = await prepareToClickOnAuthority();
     await selectLocalAuthority(localAuthorityId0, user);
-    expect(establishmentRequestLocalAuthorityIds()).toEqual([localAuthorityId0]); // errors don't appear in this list.
+    expect(establishmentRequestLocalAuthorityIds()).toEqual([localAuthorityId0]); // network errors aren't sent as MSW events.
   });
 
   it('retries Establishments request if there is a 429 response', async () => {

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -40,6 +40,16 @@ async function checkAuthoritiesList() {
   });
 }
 
+async function prepareToClickOnAuthority() {
+  const user = userEvent.setup();
+  render(<RenderWithStore><App/></RenderWithStore>);
+  checkBoilerplate();
+  await checkAuthoritiesList();
+  checkBoilerplate();
+  expect(establishmentRequestLocalAuthorityIds()).toHaveLength(0);
+  return user;
+}
+
 async function selectLocalAuthority(
   localAuthorityId: number,
   user: UserEvent
@@ -186,16 +196,6 @@ describe("App", () => {
     checkBoilerplate();
     expect(screen.getByTestId("authorities_loading")).toHaveTextContent(/^loading...$/);
   });
-
-  const prepareToClickOnAuthority = async () => {
-    const user = userEvent.setup();
-    render(<RenderWithStore><App/></RenderWithStore>);
-    checkBoilerplate();
-    await checkAuthoritiesList();
-    checkBoilerplate();
-    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(0);
-    return user;
-  };
 
   it('shows rating if click on establishments, caching data correctly', async () => {
     const user = await prepareToClickOnAuthority();

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -88,9 +88,11 @@ const localAuthorityIdToToken = (localAuthorityId: number) => `LOCAL_AUTHORITY_I
 
 // Mock the API.
 const localAuthorities: LocalAuthority[] = [
-  243433,
-  3823423,
-  123523344
+  1,
+  28,
+  323,
+  4874,
+  53567
 ].map(localAuthorityId => {
   return {
     name: localAuthorityIdToName(localAuthorityId),
@@ -219,6 +221,28 @@ describe("App", () => {
     );
     await selectLocalAuthority(localAuthorities[2].localAuthorityId, user);
     expect(establishmentRequestLocalAuthorityIds()).toHaveLength(3); // errors don't appear in this list.
+
+    // item 3 with 429 response on first attempt
+    server.use(
+      http.get(
+        serverURL("localAuthority/:localAuthorityId"),
+        () => new HttpResponse('busy', { status: 429 }),
+        { once: true }
+      )
+    );
+    await selectLocalAuthority(localAuthorities[3].localAuthorityId, user);
+    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(5);
+
+    // item 4 with 502 response on first attempt
+    server.use(
+      http.get(
+        serverURL("localAuthority/:localAuthorityId"),
+        () => new HttpResponse('timeout', { status: 502 }),
+        { once: true }
+      )
+    );
+    await selectLocalAuthority(localAuthorities[4].localAuthorityId, user);
+    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(7);
 
   }, { timeout: 10000 });
 

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -96,6 +96,8 @@ const localAuthorities: LocalAuthority[] = [
     localAuthorityId
   };
 });
+const localAuthorityId0 = localAuthorities[0].localAuthorityId;
+const localAuthorityId1 = localAuthorities[1].localAuthorityId;
 const establishmentsJson : (localAuthorityId: number) => Establishments = (localAuthorityId) => ({
   epochMillis: epoch.getTime(),
   ratingCounts: [
@@ -114,7 +116,11 @@ const establishmentRequestLocalAuthorityIds = () => flatMap(responseRecords, (re
   const url = new URL(responseRecord.request.url);
   const pattern = escapeRegExp(`${BASE_PATHNAME}/localAuthority/`) + '([0-9]+)';
   const match = url.pathname.match(pattern);
-  return match ? [ match[1] ] : [];
+  if (match) {
+    return parseInt(match[1]);
+  } else {
+    return [];
+  }
 }));
 
 // Configure mocking of API.
@@ -195,16 +201,14 @@ describe("App", () => {
     const user = await prepareToClickOnAuthority();
 
     // item 0.
-    const localAuthorityId0 = localAuthorities[0].localAuthorityId;
     await selectLocalAuthority(localAuthorityId0, user);
     expect(establishmentRequestLocalAuthorityIds()).toHaveLength(1);
-    expect(last(establishmentRequestLocalAuthorityIds())).toEqual(localAuthorityId0.toString());
+    expect(last(establishmentRequestLocalAuthorityIds())).toEqual(localAuthorityId0);
 
     // item 1.
-    const localAuthorityId1 = localAuthorities[1].localAuthorityId;
     await selectLocalAuthority(localAuthorityId1, user);
     expect(establishmentRequestLocalAuthorityIds()).toHaveLength(2);
-    expect(last(establishmentRequestLocalAuthorityIds())).toEqual(localAuthorityId1.toString());
+    expect(last(establishmentRequestLocalAuthorityIds())).toEqual(localAuthorityId1);
 
     // item 0 again.
     await selectLocalAuthority(localAuthorities[1].localAuthorityId, user);
@@ -220,8 +224,8 @@ describe("App", () => {
       )
     );
     const user = await prepareToClickOnAuthority();
-    await selectLocalAuthority(localAuthorities[0].localAuthorityId, user);
-    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(1); // errors don't appear in this list.
+    await selectLocalAuthority(localAuthorityId0, user);
+    expect(establishmentRequestLocalAuthorityIds()).toEqual([localAuthorityId0]); // errors don't appear in this list.
   });
 
   it('retries Establishments request if there is a 429 response', async () => {
@@ -233,8 +237,8 @@ describe("App", () => {
       )
     );
     const user = await prepareToClickOnAuthority();
-    await selectLocalAuthority(localAuthorities[0].localAuthorityId, user);
-    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(2);
+    await selectLocalAuthority(localAuthorityId0, user);
+    expect(establishmentRequestLocalAuthorityIds()).toEqual([localAuthorityId0, localAuthorityId0]);
   });
 
   it('retries Establishments request if there is a 502 response', async () => {
@@ -246,8 +250,8 @@ describe("App", () => {
       )
     );
     const user = await prepareToClickOnAuthority();
-    await selectLocalAuthority(localAuthorities[0].localAuthorityId, user);
-    expect(establishmentRequestLocalAuthorityIds()).toHaveLength(2);
+    await selectLocalAuthority(localAuthorityId0, user);
+    expect(establishmentRequestLocalAuthorityIds()).toEqual([localAuthorityId0, localAuthorityId0]);
   });
 
   it("retries authorities list request on network error", async () => {

--- a/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/EstablishmentsTests.java
+++ b/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/EstablishmentsTests.java
@@ -18,7 +18,7 @@ public final class EstablishmentsTests {
                 "AwaitingInspection",
                 "AwaitingPublication", "AwaitingPublication", "AwaitingPublication");
         final long epochMillis = System.currentTimeMillis();
-        final Establishments establishments = Establishments.createInstance(fsaEstablishments);
+        final Establishments establishments = Establishments.createInstance(epochMillis, fsaEstablishments);
         final List<RatingCount> actual = establishments.getRatingCounts();
         final SortedMap<String,Long> expected = fsaEstablishments.getRatingCounts();
         assertEquals(expected.size(), actual.size());


### PR DESCRIPTION
Both retries and debouncing aim to avoid problems from server overload:

* API gateway rate limiting giving 429 responses. The API gateway is deliberately configured with low rate limit to keep worst-case costs down and to make sure that app can cope with rate limiting. 
* lambda timeouts causing 502 responses when making enough concurrent requests that need to start new lambda instance.

Retries with exponential backoff mean app should recover if do get overloaded. The debouncing should make it hard for one browser to cause overload when e.g. use keyboard arrow keys to change which local authority is selected.

https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#automatic-retries
https://github.com/xnimorz/use-debounce