### PR TITLE
Fix sentry DSN problem

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./bin/setup
 
     - name: assemble
-      run: ./gradlew --scan assemble
+      run: ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' dist/ | md5sum
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_DSN_SPRING_EXPERIMENTS: ${{ secrets.SENTRY_DSN_SPRING_EXPERIMENTS }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./bin/setup
 
     - name: assemble
-      run: ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' dist/ | md5sum
+      run: echo "${SENTRY_DSN_SPRING_EXPERIMENTS}" | md5sum && ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' dist/ | md5sum
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_DSN_SPRING_EXPERIMENTS: ${{ secrets.SENTRY_DSN_SPRING_EXPERIMENTS }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./bin/setup
 
     - name: assemble
-      run: echo "${SENTRY_DSN_SPRING_EXPERIMENTS}" | md5sum && ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' dist/ | md5sum
+      run: echo "${SENTRY_DSN_SPRING_EXPERIMENTS}" | md5sum && ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' src/frontend/dist/ | md5sum
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_DSN_SPRING_EXPERIMENTS: ${{ secrets.SENTRY_DSN_SPRING_EXPERIMENTS }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./bin/setup
 
     - name: assemble
-      run: echo "${SENTRY_DSN_SPRING_EXPERIMENTS}" | md5sum && ./gradlew --scan assemble && egrep -rh --only-matching 'dsn:"[^"]*"' src/frontend/dist/ | md5sum
+      run: ./gradlew --scan src:frontend:npm_run_build assemble
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_DSN_SPRING_EXPERIMENTS: ${{ secrets.SENTRY_DSN_SPRING_EXPERIMENTS }}

--- a/README.md
+++ b/README.md
@@ -89,28 +89,37 @@ http://localhost:3000/
 
 API requests are forwarded to the spring boot server using proxy in vite.config.ts.
 
-To run production build locally:
-
-```
-vite preview
-```
-
 To test locally on mobile device:
 
 ```
 adb reverse tcp:3000 tcp:3000
 ```
 
+To run front-end production build locally:
+
+```
+npm run build
+vite preview
+```
+
 ## Release Build Instructions
 
-Build using one of:
+Build front end first:
+
+```
+cd src/frontend
+npm install
+npm run build
+```
+
+Build jar using one of:
 
 ```
 ./gradlew bootJar # to run locally
 ./gradlew shadowJar # for AWS lambda
 ```
 
-The React app will be built and bundled into the jar.
+The jar will include latest front-end from src/frontend/dist/, put there by above build command.
 
 ## IDEs
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,11 @@
 * Why are there no sentry.io requests from production in browser network connection debugger?
   - vite preview doesn't have this problem
-  - DSN doesn't seem to be in js bundle.
+  - browser requesting https://aws.jeremygreen.me.uk/assets/index-cQ6a5IW-.js
+  - e317 is reported in the App tooltip as version
+  - that's built by https://github.com/jg210/spring-experiments/actions/runs/7976066640
+  - has AWS jar artifact with public/assets/index-UNBOAu1w.js that has sentry DSN in it
+  - why are filenames different?
+    - ...since publish is rebuilding the dist/ directory.   
 
 * https://jeremy-green.sentry.io/settings/projects/spring-experiments/source-maps/release-bundles/spring-experiments%40e317e71/
   - current lambda release

--- a/TODO
+++ b/TODO
@@ -1,4 +1,6 @@
 * Why are there no sentry.io requests from production in browser network connection debugger?
+  - vite preview doesn't have this problem
+  - DSN doesn't seem to be in js bundle.
 
 * https://jeremy-green.sentry.io/settings/projects/spring-experiments/source-maps/release-bundles/spring-experiments%40e317e71/
   - current lambda release

--- a/TODO
+++ b/TODO
@@ -1,12 +1,3 @@
-* Why are there no sentry.io requests from production in browser network connection debugger?
-  - vite preview doesn't have this problem
-  - browser requesting https://aws.jeremygreen.me.uk/assets/index-cQ6a5IW-.js
-  - e317 is reported in the App tooltip as version
-  - that's built by https://github.com/jg210/spring-experiments/actions/runs/7976066640
-  - has AWS jar artifact with public/assets/index-UNBOAu1w.js that has sentry DSN in it
-  - why are filenames different?
-    - ...since publish is rebuilding the dist/ directory.   
-
 * https://jeremy-green.sentry.io/settings/projects/spring-experiments/source-maps/release-bundles/spring-experiments%40e317e71/
   - current lambda release
   - no source maps uploaded according to sentry.io

--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,6 @@ if (hasProperty('buildScan')) {
     }
 }
 
-// Add React frontend artifacts to the jars.
-[shadowJar, bootJar].each { jar ->
-    jar.dependsOn('src:frontend:npm_run_build')
-}
 bootJar {
     from("${project('src:frontend').projectDir}/dist") {
         into("public")

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -6,6 +6,10 @@ import viteTsconfigPaths from 'vite-tsconfig-paths';
 import { execSync } from 'child_process';
 
 const commitHash = execSync('git rev-parse --short HEAD').toString();
+const sentryDsn = process.env.SENTRY_DSN_SPRING_EXPERIMENTS;
+if (sentryDsn == undefined) {
+    throw new Error("SENTRY_DSN_SPRING_EXPERIMENTS env. var. / secret not set.");
+}
 
 export default defineConfig({
     // depending on your application, base can also be "/"
@@ -23,7 +27,7 @@ export default defineConfig({
     define: {
         __COMMIT_HASH__: JSON.stringify(commitHash),
         __APP_NAME__: JSON.stringify(process.env.npm_package_name),
-        __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN_SPRING_EXPERIMENTS)
+        __SENTRY_DSN__: JSON.stringify(sentryDsn)
     },
 
     server: {    


### PR DESCRIPTION
A build.gradle dependency on npm tasks meant that publish task was rerunning vite build, but without sentry auth token or DSN. That meant that github and s3 artifacts were different, sentry was not working in production and likely affected source map upload too.

https://github.com/jg210/spring-experiments/pull/47/files#diff-a901835df5a31bc664262008ce7000b12a1c811dca5f124df9bf129b9256588f adds a check that ensures build would fail if DSN not set again for some reason.