### PR TITLE
Fix source map upload and add a crash test to UI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ classDiagram
     class TableRow {
         RatingPercentage ratingPercentage
     }
+    class RetrievalDate {
+        onTripleClick
+        Date epoch
+    }
     %% Relationships
     LocalAuthorities --> "*" LocalAuthority
     LocalAuthority ..> "1" Establishments
@@ -53,6 +57,7 @@ classDiagram
     App --> "1" Authorities
     App --> "1" Table
     Table --> "*" TableRow
+    Table --> "1" RetrievalDate
 ```
 The [front end](src/frontend) uses [React](https://react.dev/). It uses [React Tool Kit Query](https://redux-toolkit.js.org/rtk-query/overview) to connect to the API. Type checking is done using [TypeScript](https://www.typescriptlang.org/).
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,11 @@
 * Are source map uploads working properly now?
 
+* Send unexpected HTTP response codes to sentry.
+  - before or after retries?
+  - how?
+    - via wrapper for hook?
+    - https://redux-toolkit.js.org/rtk-query/usage/error-handling#handling-errors-at-a-macro-level
+
 * Sentry-github integration
   - https://docs.sentry.io/product/integrations/source-code-mgmt/github/
 

--- a/TODO
+++ b/TODO
@@ -1,9 +1,4 @@
-* https://jeremy-green.sentry.io/settings/projects/spring-experiments/source-maps/release-bundles/spring-experiments%40e317e71/
-  - current lambda release
-  - no source maps uploaded according to sentry.io
-  - but they were uploaded according to this
-    - https://github.com/jg210/spring-experiments/actions/runs/7976066640/job/21775743397
-      -  [sentry-vite-plugin] Info: Successfully uploaded source maps to Sentry
+* Are source map uploads working properly now?
 
 * Sentry-github integration
   - https://docs.sentry.io/product/integrations/source-code-mgmt/github/

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import './App.css';
 import { Authorities } from './Authorities';
 import { Table } from './Table';
-import { sentryRelease } from './sentry';
 import CookieConsent from 'react-cookie-consent';
 
 export const App  = () => {
@@ -11,7 +10,7 @@ export const App  = () => {
         <>
             <div className="App">
                 <header className="App-header">
-                    <h1 title={sentryRelease} className="App-title">FSA Food Hygiene Ratings</h1>
+                    <h1 title={__SENTRY_RELEASE__} className="App-title">FSA Food Hygiene Ratings</h1>
                 </header>
                 <div data-testid="blurb" className="App-blurb">
                     <p>The information provided here is based on data from the Food Standards Agency UK Food Hygiene Rating Data <a href="https://ratings.food.gov.uk">API</a>.</p>

--- a/src/frontend/src/RetrievalDate.tsx
+++ b/src/frontend/src/RetrievalDate.tsx
@@ -1,9 +1,9 @@
-interface RetrievalDataProps {
+interface RetrievalDateProps {
     epoch: Date
     onTripleClick: () => void
 }
 
-export const RetrievalDate = ({ epoch, onTripleClick } : RetrievalDataProps) => {
+export const RetrievalDate = ({ epoch, onTripleClick } : RetrievalDateProps) => {
     const dateString = epoch.toLocaleString();
     const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
         if (e.detail === 3) {

--- a/src/frontend/src/RetrievalDate.tsx
+++ b/src/frontend/src/RetrievalDate.tsx
@@ -1,0 +1,10 @@
+interface RetrievalDataProps {
+    epochMillis: number
+}
+
+export const RetrievalDate = ({epochMillis} : RetrievalDataProps) => {
+    const dateString = new Date(epochMillis).toLocaleString();
+    return (
+         <div data-testid="retrieved" className="retrieved">retrieved {dateString}</div>
+    );
+};

--- a/src/frontend/src/RetrievalDate.tsx
+++ b/src/frontend/src/RetrievalDate.tsx
@@ -1,10 +1,10 @@
 interface RetrievalDataProps {
-    epochMillis: number
+    epoch: Date
     onTripleClick: () => void
 }
 
-export const RetrievalDate = ({ epochMillis, onTripleClick } : RetrievalDataProps) => {
-    const dateString = new Date(epochMillis).toLocaleString();
+export const RetrievalDate = ({ epoch, onTripleClick } : RetrievalDataProps) => {
+    const dateString = epoch.toLocaleString();
     const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
         if (e.detail === 3) {
             onTripleClick();

--- a/src/frontend/src/RetrievalDate.tsx
+++ b/src/frontend/src/RetrievalDate.tsx
@@ -1,10 +1,16 @@
 interface RetrievalDataProps {
     epochMillis: number
+    onTripleClick: () => void
 }
 
-export const RetrievalDate = ({epochMillis} : RetrievalDataProps) => {
+export const RetrievalDate = ({ epochMillis, onTripleClick } : RetrievalDataProps) => {
     const dateString = new Date(epochMillis).toLocaleString();
+    const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.detail === 3) {
+            onTripleClick();
+        }
+    };
     return (
-         <div data-testid="retrieved" className="retrieved">retrieved {dateString}</div>
+         <div data-testid="retrieved" className="retrieved" onClick={onClick}>retrieved {dateString}</div>
     );
 };

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -14,6 +14,8 @@ interface TableProps {
 
 const DEBOUNCE_INTERVAL_MILLIS = 1000;
 
+export const onRetrievalDateTripleClick = () => { throw new Error("crash test") };
+
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
     // Scrolling through list of local authorities by holding down up or down
@@ -52,7 +54,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
                     ))}
                 </tbody>
             </table>
-            <RetrievalDate epochMillis={currentData.epochMillis} />
+            <RetrievalDate epochMillis={currentData.epochMillis} onTripleClick={onRetrievalDateTripleClick} />
         </div>
     );
 };

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -39,6 +39,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
         );
     }
     const scores = ratingsPercentages(currentData);
+    const epoch = new Date(currentData.epochMillis);
     return (
         <div>
             <table className="Table">
@@ -53,8 +54,8 @@ export const Table = ({ localAuthorityId }: TableProps) => {
                         <TableRow ratingPercentage={ratingPercentage} key={i}/>
                     ))}
                 </tbody>
-            </table>
-            <RetrievalDate epochMillis={currentData.epochMillis} onTripleClick={onRetrievalDateTripleClick} />
+            </table>            
+            <RetrievalDate epoch={epoch} onTripleClick={onRetrievalDateTripleClick} />
         </div>
     );
 };

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -6,6 +6,7 @@ import {
     RATINGS_REFRESH_INTERVAL_SECONDS
 } from './FSA';
 import { TableRow } from './TableRow';
+import { RetrievalDate } from './RetrievalDate';
 
 interface TableProps {
     localAuthorityId: number;
@@ -36,7 +37,6 @@ export const Table = ({ localAuthorityId }: TableProps) => {
         );
     }
     const scores = ratingsPercentages(currentData);
-    const dateString = new Date(currentData.epochMillis).toLocaleString();
     return (
         <div>
             <table className="Table">
@@ -52,7 +52,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
                     ))}
                 </tbody>
             </table>
-            <div data-testid="retrieved" className="retrieved">retrieved {dateString}</div>
+            <RetrievalDate epochMillis={currentData.epochMillis} />
         </div>
     );
 };

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -54,7 +54,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
                         <TableRow ratingPercentage={ratingPercentage} key={i}/>
                     ))}
                 </tbody>
-            </table>            
+            </table>
             <RetrievalDate epoch={epoch} onTripleClick={onRetrievalDateTripleClick} />
         </div>
     );

--- a/src/frontend/src/__tests__/RetrievalDate.test.tsx
+++ b/src/frontend/src/__tests__/RetrievalDate.test.tsx
@@ -7,8 +7,10 @@ describe("RetrievalDate component", () => {
 
   it("shows retrieval date", () => {
     const epoch = new Date();
-    render(<RenderWithStore><RetrievalDate epochMillis={epoch.getTime()} /></RenderWithStore>);
+    const onTripleClick = vi.fn();
+    render(<RenderWithStore><RetrievalDate epoch={epoch} onTripleClick={onTripleClick} /></RenderWithStore>);
     expect(screen.getByTestId("retrieved")).toHaveTextContent(`retrieved ${epoch.toLocaleString()}`);
+    expect(onTripleClick).toHaveBeenCalledTimes(0);
   });
 
   it("triple click", async () => {
@@ -17,7 +19,7 @@ describe("RetrievalDate component", () => {
     render(
       <RenderWithStore>
         <RetrievalDate
-          epochMillis={epoch.getTime()}
+          epoch={epoch}
           onTripleClick={onTripleClick}
         />
       </RenderWithStore>

--- a/src/frontend/src/__tests__/RetrievalDate.test.tsx
+++ b/src/frontend/src/__tests__/RetrievalDate.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { RenderWithStore } from "./util";
+import { RetrievalDate } from "../RetrievalDate";
+
+describe("RetrievalDate component", () => {
+
+  it("shows retrieval date", () => {
+    const epoch = new Date();
+    render(<RenderWithStore><RetrievalDate epochMillis={epoch.getTime()} /></RenderWithStore>);
+    expect(screen.getByTestId("retrieved")).toHaveTextContent(`retrieved ${epoch.toLocaleString()}`);
+  });
+
+});

--- a/src/frontend/src/__tests__/RetrievalDate.test.tsx
+++ b/src/frontend/src/__tests__/RetrievalDate.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { RenderWithStore } from "./util";
 import { RetrievalDate } from "../RetrievalDate";
+import userEvent from "@testing-library/user-event";
 
 describe("RetrievalDate component", () => {
 
@@ -8,6 +9,24 @@ describe("RetrievalDate component", () => {
     const epoch = new Date();
     render(<RenderWithStore><RetrievalDate epochMillis={epoch.getTime()} /></RenderWithStore>);
     expect(screen.getByTestId("retrieved")).toHaveTextContent(`retrieved ${epoch.toLocaleString()}`);
+  });
+
+  it("triple click", async () => {
+    const epoch = new Date();
+    const onTripleClick = vi.fn();
+    render(
+      <RenderWithStore>
+        <RetrievalDate
+          epochMillis={epoch.getTime()}
+          onTripleClick={onTripleClick}
+        />
+      </RenderWithStore>
+    );
+    expect(screen.getByTestId("retrieved")).toHaveTextContent(`retrieved ${epoch.toLocaleString()}`);
+    const user = userEvent.setup();
+    const retrievedElement = screen.getByTestId("retrieved");
+    await user.tripleClick(retrievedElement);
+    expect(onTripleClick).toHaveBeenCalledOnce();
   });
 
 });

--- a/src/frontend/src/__tests__/Table.test.tsx
+++ b/src/frontend/src/__tests__/Table.test.tsx
@@ -1,4 +1,4 @@
-import { Table } from "../Table";
+import { Table, onRetrievalDateTripleClick } from "../Table";
 import { render, screen } from "@testing-library/react";
 import { RenderWithStore } from "./util";
 
@@ -9,6 +9,10 @@ describe("Table component", () => {
     render(<RenderWithStore><Table localAuthorityId={localAuthorityId} /></RenderWithStore>);
     const loadingElement = screen.getByTestId("table_loading");
     expect(loadingElement).toHaveTextContent("loading...");
+  });
+
+  it("handles triple click with crash test", () => {
+    expect(onRetrievalDateTripleClick).toThrowError(new Error("crash test"));
   });
 
 });

--- a/src/frontend/src/sentry.tsx
+++ b/src/frontend/src/sentry.tsx
@@ -1,13 +1,11 @@
 import * as Sentry from "@sentry/react";
 import React from "react";
 
-export const sentryRelease = __APP_NAME__ + '@' + __COMMIT_HASH__;
-
 export const sentryInit = () => {
     Sentry.init({
         dsn: __SENTRY_DSN__,
         environment: import.meta.env.MODE,
-        release: sentryRelease,
+        release: __SENTRY_RELEASE__,
         integrations: [
             Sentry.browserTracingIntegration(),
             Sentry.replayIntegration({

--- a/src/frontend/vite-env.d.ts
+++ b/src/frontend/vite-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __COMMIT_HASH__: string;
 declare const __APP_NAME__: string;
+declare const __COMMIT_HASH__: string;
 declare const __SENTRY_DSN__: string;
+declare const __SENTRY_RELEASE__: string;

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -4,9 +4,9 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import { execSync } from 'child_process';
+import { name as appName } from './package.json';
 
 const commitHash = execSync('git rev-parse HEAD').toString().trim();
-const appName = process.env.npm_package_name;
 const sentryRelease = appName + '@' + commitHash;
 const sentryDSN = process.env.SENTRY_DSN_SPRING_EXPERIMENTS;
 
@@ -19,7 +19,7 @@ export default defineConfig({
         viteTsconfigPaths(),
         sentryVitePlugin({
             org: "jeremy-green",
-            project: "spring-experiments",
+            project: appName,
             release: {
                 name: sentryRelease
             }

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -5,7 +5,10 @@ import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import { execSync } from 'child_process';
 
-const commitHash = execSync('git rev-parse --short HEAD').toString();
+const commitHash = execSync('git rev-parse HEAD').toString();
+const appName = process.env.npm_package_name;
+const sentryRelease = appName + '@' + commitHash;
+const sentryDSN = process.env.SENTRY_DSN_SPRING_EXPERIMENTS;
 
 export default defineConfig({
     // depending on your application, base can also be "/"
@@ -16,14 +19,18 @@ export default defineConfig({
         viteTsconfigPaths(),
         sentryVitePlugin({
             org: "jeremy-green",
-            project: "spring-experiments"
+            project: "spring-experiments",
+            release: {
+                name: sentryRelease
+            }
         })
     ],
 
     define: {
+        __APP_NAME__: JSON.stringify(appName),
         __COMMIT_HASH__: JSON.stringify(commitHash),
-        __APP_NAME__: JSON.stringify(process.env.npm_package_name),
-        __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN_SPRING_EXPERIMENTS)
+        __SENTRY_DSN__: JSON.stringify(sentryDSN),
+        __SENTRY_RELEASE__: JSON.stringify(sentryRelease)
     },
 
     server: {    

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import { execSync } from 'child_process';
 
-const commitHash = execSync('git rev-parse HEAD').toString();
+const commitHash = execSync('git rev-parse HEAD').toString().trim();
 const appName = process.env.npm_package_name;
 const sentryRelease = appName + '@' + commitHash;
 const sentryDSN = process.env.SENTRY_DSN_SPRING_EXPERIMENTS;


### PR DESCRIPTION
Were setting release name at runtime, but not when uploading source maps at build time. Former was using `spring-experiments@<short git commit hash>` and latter was using full git commit hash.

This PR:

* sets both to `spring-experiments@<full git commit hash>`
* rearranges code a little to prevent circularities
* stops appName from being undefined if run `vite build` not `npm run build`.
* throws crash-test exception if triple click on "retrieved" text, so can test sentry in production.