### PR TITLE
No debouncing of cached data

### DIFF
--- a/TODO
+++ b/TODO
@@ -80,6 +80,9 @@
   - https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#uselazyquery?
   - useQuery with skip set to true and refetch()?
 
+* Prefetch data when scrolling through list.
+  - ideas from https://github.com/reduxjs/redux-toolkit/discussions/3174 might be relevant?
+
 * Split github action job into multiple jobs.
 
 * Should be able to use shadowJar in place of bootJar.

--- a/TODO
+++ b/TODO
@@ -63,23 +63,6 @@
 
 * Automated licence management.
 
-* Debounce API requests after cache not before.
-  - 50c4acf244ade00c129075fa6dd38f43cdaf3a54 mitigates this
-  - would still be nice if could bypass debouncing if results are cached
-    - e.g. if press up and down arrow in list faster than debounce rate
-  - might then run into rendering bottleneck?
-    - Suspense?
-  - might be hard to implement since what would RTK query return if debounce away a request?
-  - in general, should debounce per hook-usage, not in createApi()
-    - there might be multiple components using same API.
-    - is there a way to base options to baseQuery with useQuery?
-  - combine useQueryState and useQuery?
-    - former doesn't make requests
-    - can't call hooks conditionally, so would have to call both
-      - not necessarily bad, since latter would be debounced
-  - https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#uselazyquery?
-  - useQuery with skip set to true and refetch()?
-
 * Prefetch data when scrolling through list.
   - ideas from https://github.com/reduxjs/redux-toolkit/discussions/3174 might be relevant?
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,5 @@
+* skipPollingIfUnfocused.
+
 * Send unexpected HTTP response codes to sentry.
   - before or after retries?
   - how?
@@ -68,6 +70,15 @@
   - might then run into rendering bottleneck?
     - Suspense?
   - might be hard to implement since what would RTK query return if debounce away a request?
+  - in general, should debounce per hook-usage, not in createApi()
+    - there might be multiple components using same API.
+    - is there a way to base options to baseQuery with useQuery?
+  - combine useQueryState and useQuery?
+    - former doesn't make requests
+    - can't call hooks conditionally, so would have to call both
+      - not necessarily bad, since latter would be debounced
+  - https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#uselazyquery?
+  - useQuery with skip set to true and refetch()?
 
 * Split github action job into multiple jobs.
 

--- a/src/frontend/src/Authorities.tsx
+++ b/src/frontend/src/Authorities.tsx
@@ -1,7 +1,7 @@
 import {
     LocalAuthority,
     RATINGS_REFRESH_INTERVAL_SECONDS,
-    useGetLocalAuthoritiesQuery
+    fsaApi,
 } from './FSA';
 
 interface AuthoritiesProps {
@@ -10,8 +10,8 @@ interface AuthoritiesProps {
 
 // Drop down list that populates itself with list of local authorities.
 export const Authorities  = (props: AuthoritiesProps) => {
-
-    const { currentData } = useGetLocalAuthoritiesQuery(undefined, {
+    const { getLocalAuthorities } = fsaApi.endpoints;
+    const { currentData } = getLocalAuthorities.useQuery(undefined, {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS
     });

--- a/src/frontend/src/FSA.tsx
+++ b/src/frontend/src/FSA.tsx
@@ -72,5 +72,3 @@ export const fsaApi = createApi({
     })
   })
 });
-
-export const { useGetLocalAuthoritiesQuery, useGetEstablishmentsQuery } = fsaApi;

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -19,8 +19,6 @@ export const onRetrievalDateTripleClick = () => { throw new Error("crash test") 
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
     const { getEstablishments } = fsaApi.endpoints;
-    // Is the data in the RTK query cache?
-    const cachedData = getEstablishments.useQueryState(localAuthorityId).currentData;
     // Scrolling through list of local authorities by holding down up or down
     // arrow keys generates a lot of renders, so need to limit the number of
     // API requests.
@@ -39,10 +37,12 @@ export const Table = ({ localAuthorityId }: TableProps) => {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS
     });
+    // Is the data in the RTK query cache?
+    const cachedData = getEstablishments.useQueryState(localAuthorityId).currentData;
+    const isCached = cachedData !== undefined;
     // The isPending() returned by useDebounce doesn't work if leading set to true,
     // so compare prop and debounced value instead.
     const isDebounced = localAuthorityId !== localAuthorityIdDebounced;
-    const isCached = cachedData !== undefined;
     const isUpdating = !isCached && (isFetching || isDebounced);
     const establishments = isCached ? cachedData : data;
     if (establishments == undefined) {

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -43,7 +43,6 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     const isDebounced = localAuthorityId !== localAuthorityIdDebounced;
     const isCached = cachedData !== undefined;
     const isUpdating = !isCached && (isFetching || isDebounced);
-    //console.log(JSON.stringify({isDebounced, isCached, isUpdating}));
     const establishments = isCached ? cachedData : data;
     if (establishments == undefined) {
         return (

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -33,7 +33,8 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     // fetching. It doesn't get set to undefined, but keeps providing
     // the last result. This is visually less jarring than the "loading..."
     // text need before any data is loaded. Loading indication is instead done
-    // using TableUpdating CSS style.
+    // using TableUpdating CSS style. Hooks can't be called conditionally, so
+    // still need to call this even if cachedData is not undefined.
     const { data, isFetching } = getEstablishments.useQuery(localAuthorityIdDebounced, {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -2,7 +2,6 @@ import { useDebounce } from 'use-debounce';
 import {
     ratingsPercentages,
     RatingPercentage,
-    useGetEstablishmentsQuery,
     RATINGS_REFRESH_INTERVAL_SECONDS,
     fsaApi
 } from './FSA';
@@ -19,8 +18,9 @@ export const onRetrievalDateTripleClick = () => { throw new Error("crash test") 
 
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
+    const { getEstablishments } = fsaApi.endpoints;
     // Is the data in the RTK query cache?
-    const cachedData = fsaApi.endpoints.getEstablishments.useQueryState(localAuthorityId).currentData;
+    const cachedData = getEstablishments.useQueryState(localAuthorityId).currentData;
     // Scrolling through list of local authorities by holding down up or down
     // arrow keys generates a lot of renders, so need to limit the number of
     // API requests.
@@ -34,7 +34,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     // the last result. This is visually less jarring than the "loading..."
     // text need before any data is loaded. Loading indication is instead done
     // using TableUpdating CSS style.
-    const { data, isFetching } = useGetEstablishmentsQuery(localAuthorityIdDebounced, {
+    const { data, isFetching } = getEstablishments.useQuery(localAuthorityIdDebounced, {
         pollingInterval: RATINGS_REFRESH_INTERVAL_SECONDS * 1000,
         refetchOnMountOrArgChange: RATINGS_REFRESH_INTERVAL_SECONDS
     });


### PR DESCRIPTION
The app uses debouncing to make sure that don't make too many API requests if e.g. scroll through list very fast using arrow keys. To indicate stale data when debounced (and also if just fetching data), the table opacity is reduced to 20%.

This works and looks not too bad, but could be better... If the data is cached locally, there's no need to debounce to protect the API and should be able to change between local authorities as fast as want to.

There are a few ways might try to avoid debouncing for cached data:

* Move debouncing into TRK query's baseQuery?  What would RTK query return if debounce away a request? A fake 429 perhaps? In general, should debounce per hook-usage, not in createApi() since there might be multiple components using same API. Is there a way to base options to baseQuery with useQuery?
* Use https://redux-toolkit.js.org/rtk-query/api/created-api/hooks#uselazyquery? Need to call trigger functon (in a useEffect) to run the query, so can control this. refetchOnMountOrArgChange would need to be implemented manually since useLazyQuery() doesn't have it. eslint hook rule complains if trigger isn't is useEffect dependencies. Don't have useEffectEvent in stable react.  Is trigger memoized by RTK query? Wouldn't know if data is cached unless use e.g. useQueryState(), so this seems to be similar to the solution I eventually used, but with added complexity.
* useQuery with skip set to true and refetch()? Probably quite similar to useLazyQuery()? skipToken is preferred to skip for TypeScript.

Went for this one approach in this PR:

* Combine useQueryState and useQuery. Former doesn't make requests. Can't call hooks conditionally, so have to call both, which is not bad, since latter would be debounced or return same cached data.

