### PR TITLE
Show all ratings for all local authorities and right align table text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ classDiagram
         number count
     }
     class RatingPercentage {
-       string rating
-       number percentage
+        string rating
+        number percentage
+    }
+    class Ratings {
+        string[] ratings
     }
     %% Components
     class Authorities {

--- a/TODO
+++ b/TODO
@@ -1,6 +1,3 @@
-* Unit test Table stays in loading... state if only one of Ratings or Establishments loads.
-  - a reliable test would have to wait for the one mock network request that is made
-
 * CSS linter.
   - options
     - https://stylelint.io
@@ -14,6 +11,9 @@
 * onRetrievalDateTripleClick export prevents vite fast refresh.
   - hmr invalidate /src/Table.tsx Could not Fast Refresh.
   - Learn more at https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports
+
+* Unit test Table stays in loading... state if only one of Ratings or Establishments loads.
+  - a reliable test would have to wait for the one mock network request that is made
 
 * Sentry-github integration
   - https://docs.sentry.io/product/integrations/source-code-mgmt/github/
@@ -125,9 +125,6 @@
 * Polling of APIs could mean that a localAuthorityId disappears.
   - with much much greater probability than is currently possible.
   - but still not very likely
-
-* barGraph CSS isn't quite right
-  - if change tableCell text-align to right, 
 
 * Add favicon.ico.
 

--- a/TODO
+++ b/TODO
@@ -1,7 +1,5 @@
 * Unit test loading... state if allRatings undefined.
 
-* LocalAuthorityParams and LocalAuthoritiesParams etc. need names swapping.
-
 * CSS linter.
   - options
     - https://stylelint.io

--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
-* Unit test loading... state if allRatings undefined.
+* Unit test Table stays in loading... state if only one of Ratings or Establishments loads.
+  - a reliable test would have to wait for the one mock network request that is made
 
 * CSS linter.
   - options

--- a/TODO
+++ b/TODO
@@ -1,8 +1,12 @@
+* Unit test loading... state if allRatings undefined.
+
 * Right align text in Table.
   - so percentage symboles lined up with each other 
   - uncovers bug in way barGraph div set up though...
 
 * CSS linter.
+  - options
+    - https://stylelint.io
 
 * Send unexpected HTTP response codes to sentry.
   - before or after retries?

--- a/TODO
+++ b/TODO
@@ -1,8 +1,6 @@
 * Unit test loading... state if allRatings undefined.
 
-* Right align text in Table.
-  - so percentage symboles lined up with each other 
-  - uncovers bug in way barGraph div set up though...
+* LocalAuthorityParams and LocalAuthoritiesParams etc. need names swapping.
 
 * CSS linter.
   - options

--- a/TODO
+++ b/TODO
@@ -1,3 +1,7 @@
+* Right align text in Table.
+  - so percentage symboles lined up with each other 
+  - uncovers bug in way barGraph div set up though...
+
 * Send unexpected HTTP response codes to sentry.
   - before or after retries?
   - how?
@@ -118,6 +122,9 @@
 * Polling of APIs could mean that a localAuthorityId disappears.
   - with much much greater probability than is currently possible.
   - but still not very likely
+
+* barGraph CSS isn't quite right
+  - if change tableCell text-align to right, 
 
 * Add favicon.ico.
 

--- a/TODO
+++ b/TODO
@@ -2,6 +2,8 @@
   - so percentage symboles lined up with each other 
   - uncovers bug in way barGraph div set up though...
 
+* CSS linter.
+
 * Send unexpected HTTP response codes to sentry.
   - before or after retries?
   - how?

--- a/TODO
+++ b/TODO
@@ -153,6 +153,9 @@
   - not clear if MSW etc. work with useFakeTimers() - 8e7785d889323f7cdd464bfac074466d3d487ff3
   - polling iff brwoser window focused.
 
+* "Pass and Eat Safe" appears in Establishments but not Ratings
+  - a "feature" of the data provided by FSA API
+
 * unit test changing Table localAuthorityId shows loading... state again 
 
 * unit test for debouncing

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -39,7 +39,7 @@
 td {
   /* Want the bar graph to fill the cells. */
   padding: 0px;
-  /* barGraphContainer uses position: absolute to fill paraent, so it's parent needs position: relative. */
+  /* barGraphContainer uses position: absolute to fill paraent, so its parent needs position: relative. */
   position: relative;
 }
 

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -37,18 +37,16 @@
 }
 
 td {
+  /* Want the bar graph to fill the cells. */
   padding: 0px;
+  /* barGraphContainer uses position: absolute to fill paraent, so it's parent needs position: relative. */
+  position: relative;
 }
 
 .tableCell {
   text-align: left;
   padding-left: 1em;
   padding-right: 1em;
-}
-
-/* barGraphContainer uses position: absolute to fill paraent, so it's parent needs position: relative. */
-td:has(> .barGraphContainer) {
-  position: relative;
 }
 
 .barGraphContainer {

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -46,9 +46,22 @@ td {
   padding-right: 1em;
 }
 
+.barGraphContainer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+}
+
 .barGraph {
   background-color: bisque;
-  transition: width 500ms
+  transition: width 500ms;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
 }
 
 .retrieved {

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -44,7 +44,7 @@ td {
 }
 
 .tableCell {
-  text-align: left;
+  text-align: right;
   padding-left: 1em;
   padding-right: 1em;
 }

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -46,6 +46,11 @@ td {
   padding-right: 1em;
 }
 
+/* barGraphContainer uses position: absolute to fill paraent, so it's parent needs position: relative. */
+td:has(> .barGraphContainer) {
+  position: relative;
+}
+
 .barGraphContainer {
   position: absolute;
   top: 0;

--- a/src/frontend/src/FSA.tsx
+++ b/src/frontend/src/FSA.tsx
@@ -39,7 +39,7 @@ export interface LocalAuthorities {
   localAuthorities: LocalAuthority[]
 }
 
-interface Ratings {
+export interface Ratings {
   ratings: string[]
 }
 
@@ -47,17 +47,17 @@ interface Ratings {
 export function ratingsPercentages(establishments: Establishments, allRatings: string[]): RatingPercentage[] {
   const { ratingCounts } = establishments;
   const ratingCountMap: Map<string, number> = new Map();
-  const allRatingsSorted = [ ...allRatings ].sort();
-  allRatingsSorted.forEach((rating) => {
+  allRatings.forEach((rating) => {
     ratingCountMap.set(rating, 0);
   });
   let totalCount = 0;
-  ratingCounts.forEach((ratingCount) => {
-    ratingCountMap.set(ratingCount.rating, ratingCount.count);
-    totalCount += ratingCount.count;
+  ratingCounts.forEach(({rating, count}) => {
+    ratingCountMap.set(rating, count);
+    totalCount += count;
   });
   const result: RatingPercentage[] = [];
-  ratingCountMap.forEach((count, rating) => {
+  [...ratingCountMap.keys()].sort().forEach((rating) => {
+      const count = ratingCountMap.get(rating) as number;
       const percentage = 100 * count / totalCount;
       result.push({ rating, percentage });
   });

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -18,7 +18,7 @@ export const onRetrievalDateTripleClick = () => { throw new Error("crash test") 
 
 // Table showing percentage of establishments with each rating.
 export const Table = ({ localAuthorityId }: TableProps) => {
-    const { getEstablishments } = fsaApi.endpoints;
+    const { getEstablishments, getRatings } = fsaApi.endpoints;
     // Scrolling through list of local authorities by holding down up or down
     // arrow keys generates a lot of renders, so need to limit the number of
     // API requests.
@@ -46,12 +46,13 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     const isDebounced = localAuthorityId !== localAuthorityIdDebounced;
     const isUpdating = !isCached && (isFetching || isDebounced);
     const establishments = isCached ? cachedData : data;
+    const { data: allRatings } = getRatings.useQuery();
     if (establishments == undefined) {
         return (
             <div data-testid="table_loading">loading...</div>
         );
     }
-    const scores = ratingsPercentages(establishments);
+    const scores = ratingsPercentages(establishments, allRatings);
     const epoch = new Date(establishments.epochMillis);
     const tableClasses = ['Table'];
     if (isUpdating) {

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -46,7 +46,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     const isDebounced = localAuthorityId !== localAuthorityIdDebounced;
     const isUpdating = !isCached && (isFetching || isDebounced);
     const establishments = isCached ? cachedData : data;
-    const { data: allRatings } = getRatings.useQuery();
+    const allRatings = getRatings.useQuery().data;
     if (establishments == undefined || allRatings == undefined) {
         return (
             <div data-testid="table_loading">loading...</div>

--- a/src/frontend/src/Table.tsx
+++ b/src/frontend/src/Table.tsx
@@ -47,7 +47,7 @@ export const Table = ({ localAuthorityId }: TableProps) => {
     const isUpdating = !isCached && (isFetching || isDebounced);
     const establishments = isCached ? cachedData : data;
     const { data: allRatings } = getRatings.useQuery();
-    if (establishments == undefined) {
+    if (establishments == undefined || allRatings == undefined) {
         return (
             <div data-testid="table_loading">loading...</div>
         );

--- a/src/frontend/src/TableRow.tsx
+++ b/src/frontend/src/TableRow.tsx
@@ -12,6 +12,7 @@ export const TableRow = ({ ratingPercentage }: TableRowProps) => {
                 <div className="barGraphContainer">
                     <div className="barGraph" data-testid="barGraph" style={{width: `${ratingPercentage.percentage}%`}}/>
                 </div>
+                {/* tableCell is added here not on td since don't want padding to affect barGraph. */}
                 <div className="tableCell">{Math.round(ratingPercentage.percentage)}%</div>
             </td>
         </tr>

--- a/src/frontend/src/TableRow.tsx
+++ b/src/frontend/src/TableRow.tsx
@@ -8,7 +8,7 @@ export const TableRow = ({ ratingPercentage }: TableRowProps) => {
     return (
         <tr>
             <td className="tableCell">{ratingPercentage.rating}</td>
-            <td>
+            <td style={{ position: "relative" }}>
                 <div className="barGraphContainer">
                     <div className="barGraph" data-testid="barGraph" style={{width: `${ratingPercentage.percentage}%`}}/>
                 </div>

--- a/src/frontend/src/TableRow.tsx
+++ b/src/frontend/src/TableRow.tsx
@@ -8,7 +8,7 @@ export const TableRow = ({ ratingPercentage }: TableRowProps) => {
     return (
         <tr>
             <td className="tableCell">{ratingPercentage.rating}</td>
-            <td style={{ position: "relative" }}>
+            <td>
                 <div className="barGraphContainer">
                     <div className="barGraph" data-testid="barGraph" style={{width: `${ratingPercentage.percentage}%`}}/>
                 </div>

--- a/src/frontend/src/TableRow.tsx
+++ b/src/frontend/src/TableRow.tsx
@@ -9,9 +9,10 @@ export const TableRow = ({ ratingPercentage }: TableRowProps) => {
         <tr>
             <td className="tableCell">{ratingPercentage.rating}</td>
             <td>
-                <div className="barGraph" data-testid="barGraph" style={{width: `${ratingPercentage.percentage}%`}}>
-                    <div className="tableCell">{Math.round(ratingPercentage.percentage)}%</div>
+                <div className="barGraphContainer">
+                    <div className="barGraph" data-testid="barGraph" style={{width: `${ratingPercentage.percentage}%`}}/>
                 </div>
+                <div className="tableCell">{Math.round(ratingPercentage.percentage)}%</div>
             </td>
         </tr>
     );

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -113,6 +113,7 @@ const establishmentsJson : (localAuthorityId: number) => Establishments = (local
     { rating: localAuthorityIdToToken(localAuthorityId), count: 0 }
   ]
 });
+const ratings = [ "good", "bad", "ugly", "not in establishments json" ];
 
 // Use MSW events (subscribed to later on) to check what requests have been made.
 type ResponseRecord = { request: Request, response: Response };
@@ -138,6 +139,10 @@ type LocalAuthorityResponseBody = LocalAuthorities;
 type LocalAuthoritiesParams = { localAuthorityId: string };
 type LocalAuthoritiesRequestBody = Record<string,never>;
 type LocalAuthoritiesResponseBody = Establishments;
+type RatingsParams = Record<string,never>;
+type RatingsRequestBody = Record<string,never>;
+type RatingsResponseBody = string[];
+
 const server = setupServer(
   http.get<LocalAuthorityParams, LocalAuthorityRequestBody, LocalAuthorityResponseBody>(serverURL("localAuthority"), () => {
     return HttpResponse.json({ localAuthorities });
@@ -147,6 +152,12 @@ const server = setupServer(
     ({ params }) => {
       const localAuthorityId = parseInt(params.localAuthorityId);
       return HttpResponse.json(establishmentsJson(localAuthorityId));
+    }
+  ),
+  http.get<RatingsParams, RatingsRequestBody, RatingsResponseBody>(
+    serverURL("ratings"),
+    () => {
+      return HttpResponse.json(ratings);
     }
   )
 );

--- a/src/frontend/src/__tests__/App.test.tsx
+++ b/src/frontend/src/__tests__/App.test.tsx
@@ -133,21 +133,21 @@ const establishmentRequestLocalAuthorityIds = () => flatMap(responseRecords, (re
 // Configure mocking of API.
 //
 // TODO can any of these types be inferred from RTK Query API?
-type LocalAuthorityParams = Record<string,never>;
-type LocalAuthorityRequestBody = Record<string,never>;
-type LocalAuthorityResponseBody = LocalAuthorities;
-type LocalAuthoritiesParams = { localAuthorityId: string };
+type LocalAuthoritiesParams = Record<string,never>;
 type LocalAuthoritiesRequestBody = Record<string,never>;
-type LocalAuthoritiesResponseBody = Establishments;
+type LocalAuthoritiesResponseBody = LocalAuthorities;
+type LocalAuthorityParams = { localAuthorityId: string };
+type LocalAuthorityRequestBody = Record<string,never>;
+type LocalAuthorityResponseBody = Establishments;
 type RatingsParams = Record<string,never>;
 type RatingsRequestBody = Record<string,never>;
 type RatingsResponseBody = string[];
 
 const server = setupServer(
-  http.get<LocalAuthorityParams, LocalAuthorityRequestBody, LocalAuthorityResponseBody>(serverURL("localAuthority"), () => {
+  http.get<LocalAuthoritiesParams, LocalAuthoritiesRequestBody, LocalAuthoritiesResponseBody>(serverURL("localAuthority"), () => {
     return HttpResponse.json({ localAuthorities });
   }),
-  http.get<LocalAuthoritiesParams, LocalAuthoritiesRequestBody, LocalAuthoritiesResponseBody>(
+  http.get<LocalAuthorityParams, LocalAuthorityRequestBody, LocalAuthorityResponseBody>(
     serverURL("localAuthority/:localAuthorityId"),
     ({ params }) => {
       const localAuthorityId = parseInt(params.localAuthorityId);

--- a/src/frontend/src/__tests__/FSA.test.tsx
+++ b/src/frontend/src/__tests__/FSA.test.tsx
@@ -139,6 +139,23 @@ describe("FSA", () => {
                 { rating: "ugly", percentage: 27 }
             ]);
         });
+        it("sorted even if allRatings lacks some values", () => {
+            const allRatings: string[] = [ "bad" ];
+            const establishements: Establishments = {
+                epochMillis,
+                ratingCounts : [
+                    { rating: "ugly", count: 270 },
+                    { rating: "good", count: 230 },
+                    { rating: "bad",  count: 500 }
+                ]
+            };
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "bad",  percentage: 50 },
+                { rating: "good", percentage: 23 },
+                { rating: "ugly", percentage: 27 }
+            ]);
+
+        });
     });
 
 });

--- a/src/frontend/src/__tests__/FSA.test.tsx
+++ b/src/frontend/src/__tests__/FSA.test.tsx
@@ -25,36 +25,64 @@ describe("FSA", () => {
 
     describe("ratingsPercentages", () => {
         const epochMillis: number = new Date("February 14, 2024 20:15:00").getTime();
-        it("no ratings", () => {
+        it("no ratings at all", () => {
+            const allRatings: string[] = [];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : []
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([]);
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([]);
         });
-        it("one rating", () => {
+        it("no ratings but some in allRatings", () => {
+            const allRatings: string[] = [ "x", "b", "q" ];
+            const establishements: Establishments = {
+                epochMillis,
+                ratingCounts : []
+            };
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "b", percentage: NaN },
+                { rating: "q", percentage: NaN },
+                { rating: "x", percentage: NaN }
+            ]);
+        });
+        it("one rating not in allRatings", () => {
+            const allRatings: string[] = [];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
                     { rating: "good", count: 14234 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "good", percentage: 100 }
+            ]);
+        });
+        it("one rating in allRatings", () => {
+            const allRatings: string[] = ["good"];
+            const establishements: Establishments = {
+                epochMillis,
+                ratingCounts : [
+                    { rating: "good", count: 14234 }
+                ]
+            };
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
                 { rating: "good", percentage: 100 }
             ]);
         });
         it("one rating but zero count", () => {
+            const allRatings: string[] = ["good"];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
                     { rating: "good", count: 0 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
                 { rating: "good", percentage: NaN }
             ]);
         });
         it("two ratings", () => {
+            const allRatings: string[] = ["good", "bad"];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
@@ -62,12 +90,13 @@ describe("FSA", () => {
                     { rating: "bad", count: 250 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
-                { rating: "good", percentage: 75 },
-                { rating: "bad",  percentage: 25 }
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "bad",  percentage: 25 },
+                { rating: "good", percentage: 75 }
             ]);
         });
         it("two ratings both zero count", () => {
+            const allRatings: string[] = ["good", "bad"];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
@@ -75,12 +104,13 @@ describe("FSA", () => {
                     { rating: "bad", count: 0 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
-                { rating: "good", percentage: NaN },
-                { rating: "bad",  percentage: NaN }
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "bad",  percentage: NaN },
+                { rating: "good", percentage: NaN }
             ]);
         });
         it("two ratings one zero count", () => {
+            const allRatings: string[] = ["good", "bad"];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
@@ -88,12 +118,13 @@ describe("FSA", () => {
                     { rating: "bad", count: 0 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
-                { rating: "good", percentage: 100 },
-                { rating: "bad",  percentage: 0 }
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
+                { rating: "bad",  percentage: 0 },
+                { rating: "good", percentage: 100 }
             ]);
         });
         it("multiple ratings", () => {
+            const allRatings = [ "good", "bad", "ugly"];
             const establishements: Establishments = {
                 epochMillis,
                 ratingCounts : [
@@ -102,9 +133,9 @@ describe("FSA", () => {
                     { rating: "ugly", count: 270 }
                 ]
             };
-            expect(ratingsPercentages(establishements)).toStrictEqual([
-                { rating: "good", percentage: 23 },
+            expect(ratingsPercentages(establishements, allRatings)).toStrictEqual([
                 { rating: "bad",  percentage: 50 },
+                { rating: "good", percentage: 23 },
                 { rating: "ugly", percentage: 27 }
             ]);
         });

--- a/src/frontend/src/__tests__/__snapshots__/TableRow.test.tsx.snap
+++ b/src/frontend/src/__tests__/__snapshots__/TableRow.test.tsx.snap
@@ -12,16 +12,19 @@ exports[`TableRow component > renders 1`] = `
         </td>
         <td>
           <div
-            class="barGraph"
-            data-testid="barGraph"
-            style="width: 23.123%;"
+            class="barGraphContainer"
           >
             <div
-              class="tableCell"
-            >
-              23
-              %
-            </div>
+              class="barGraph"
+              data-testid="barGraph"
+              style="width: 23.123%;"
+            />
+          </div>
+          <div
+            class="tableCell"
+          >
+            23
+            %
           </div>
         </td>
       </tr>

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaRating.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaRating.java
@@ -1,0 +1,18 @@
+package uk.me.jeremygreen.springexperiments.fsa;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.lang.NonNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FsaRating(@NonNull String ratingName) {
+
+    @JsonCreator
+    public FsaRating(
+            @JsonProperty("ratingName") final String ratingName
+    ) {
+        this.ratingName = ratingName;
+    }
+
+}

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatings.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatings.java
@@ -1,0 +1,18 @@
+package uk.me.jeremygreen.springexperiments.fsa;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FsaRatings(List<FsaRating> ratings) {
+
+    @JsonCreator
+    public FsaRatings(
+            @JsonProperty("ratings") final List<FsaRating> ratings
+    ) {
+        this.ratings = ratings;
+    }
+}

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaService.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/FsaService.java
@@ -95,4 +95,11 @@ public class FsaService {
         return responseEntity.getBody();
     }
 
+    public FsaRatings fetchRatings() throws InterruptedException {
+        final ResponseEntity<FsaRatings> responseEntity = fetchFromApi(
+                this.url + "/Ratings",
+                FsaRatings.class);
+        return responseEntity.getBody();
+    }
+
 }

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorities.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorities.java
@@ -21,6 +21,7 @@ public final class LocalAuthorities {
         this.localAuthorities = localAuthorities;
     }
 
+    @SuppressWarnings("unused")
     public List<LocalAuthority> getLocalAuthorities() {
         return this.localAuthorities;
     }

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthority.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthority.java
@@ -10,21 +10,23 @@ public final class LocalAuthority {
     this.name = name;
   }
 
-  public final int getLocalAuthorityId() {
+  @SuppressWarnings("unused")
+  public int getLocalAuthorityId() {
     return this.localAuthorityId;
   }
 
-  public final String getName() {
+  @SuppressWarnings("unused")
+  public String getName() {
     return this.name;
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return this.localAuthorityId;
   }
 
   @Override
-  public final boolean equals(Object o) {
+  public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
@@ -35,7 +37,7 @@ public final class LocalAuthority {
   }
 
   @Override
-  public final String toString() {
+  public String toString() {
     return this.name + "(" + this.localAuthorityId + ")";
   }
 

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorityController.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorityController.java
@@ -7,10 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.me.jeremygreen.springexperiments.fsa.FsaEstablishments;
-import uk.me.jeremygreen.springexperiments.fsa.FsaService;
-import uk.me.jeremygreen.springexperiments.fsa.FsaAuthorities;
-import uk.me.jeremygreen.springexperiments.fsa.FsaAuthority;
+import uk.me.jeremygreen.springexperiments.fsa.*;
 
 import java.util.List;
 
@@ -63,6 +60,16 @@ public final class LocalAuthorityController {
                     .body(establishments);
         }
         return responseEntity;
+    }
+
+    @GetMapping(value="ratings")
+    @SuppressWarnings("unused")
+    public ResponseEntity<Ratings> ratings() throws InterruptedException {
+        final FsaRatings fsaRatings = this.fsaService.fetchRatings();
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        return ResponseEntity.ok()
+                    .headers(RESPONSE_HEADERS)
+                    .body(ratings);
     }
 
 }

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/Ratings.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/Ratings.java
@@ -1,0 +1,25 @@
+package uk.me.jeremygreen.springexperiments.fsa.api;
+
+import org.springframework.lang.NonNull;
+import uk.me.jeremygreen.springexperiments.fsa.FsaRatings;
+
+import java.util.List;
+
+public final class Ratings {
+
+    static Ratings createInstance(final @NonNull FsaRatings fsaRatings) {
+        final List<String> ratings = fsaRatings.ratings().stream().map(fsaRating -> fsaRating.ratingName()).toList();
+        return new Ratings(ratings);
+    }
+
+    private final List<String> ratings;
+
+    Ratings(final @NonNull List<String> ratings) {
+        this.ratings = ratings;
+    }
+
+    public List<String> getRatings() {
+        return ratings;
+    }
+
+}

--- a/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/Ratings.java
+++ b/src/main/java/uk/me/jeremygreen/springexperiments/fsa/api/Ratings.java
@@ -8,7 +8,14 @@ import java.util.List;
 public final class Ratings {
 
     static Ratings createInstance(final @NonNull FsaRatings fsaRatings) {
-        final List<String> ratings = fsaRatings.ratings().stream().map(fsaRating -> fsaRating.ratingName()).toList();
+        final List<String> ratings = fsaRatings.ratings().stream().map(fsaRating -> {
+            String ratingName = fsaRating.ratingName();
+            if (ratingName.matches("^[0-9]+$")) {
+                ratingName += "-star";
+            }
+            return ratingName;
+        }
+        ).toList();
         return new Ratings(ratings);
     }
 
@@ -18,6 +25,7 @@ public final class Ratings {
         this.ratings = ratings;
     }
 
+    @SuppressWarnings("unused")
     public List<String> getRatings() {
         return ratings;
     }

--- a/src/test/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatingTest.java
+++ b/src/test/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatingTest.java
@@ -1,0 +1,15 @@
+package uk.me.jeremygreen.springexperiments.fsa;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public final class FsaRatingTest {
+
+    @Test
+    public void ratingName() {
+        final String ratingName = "foo";
+        final FsaRating fsaRating = new FsaRating(ratingName);
+        assertEquals(ratingName, fsaRating.ratingName());
+    }
+
+}

--- a/src/test/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatingsTest.java
+++ b/src/test/java/uk/me/jeremygreen/springexperiments/fsa/FsaRatingsTest.java
@@ -1,0 +1,19 @@
+package uk.me.jeremygreen.springexperiments.fsa;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public final class FsaRatingsTest {
+
+    @Test
+    public void ratings() {
+        final FsaRating fsaRating1 = new FsaRating("one");
+        final FsaRating fsaRating2 = new FsaRating("two");
+        final FsaRatings fsaRatings = new FsaRatings(List.of(fsaRating1, fsaRating2));
+        assertEquals(fsaRatings.ratings(), List.of(fsaRating1, fsaRating2));
+    }
+
+}

--- a/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorityControllerTests.java
+++ b/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/LocalAuthorityControllerTests.java
@@ -16,10 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import uk.me.jeremygreen.springexperiments.fsa.FsaAuthorities;
-import uk.me.jeremygreen.springexperiments.fsa.FsaAuthority;
-import uk.me.jeremygreen.springexperiments.fsa.FsaEstablishments;
-import uk.me.jeremygreen.springexperiments.fsa.FsaService;
+import uk.me.jeremygreen.springexperiments.fsa.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -144,6 +141,27 @@ public class LocalAuthorityControllerTests {
         }
         assertNotEquals(la1a, la2);
         assertNotEquals(la1b, la2);
+    }
+
+    @Test
+    public void ratings() throws Exception {
+        final List<FsaRating> fsaRatingsList = List.of(
+                new FsaRating("one"),
+                new FsaRating("two"),
+                new FsaRating("three")
+        );
+        final FsaRatings fsaRatings = new FsaRatings(fsaRatingsList);
+        when(this.fsaService.fetchRatings()).thenReturn(fsaRatings);
+        for (final String path: Arrays.asList(
+                "/api/fsa/ratings",
+                "/api/fsa/ratings/")) {
+            this.mockMvc.perform(get(path))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(content().json("{\"ratings\":[\"one\",\"two\",\"three\"]}"))
+                    .andExpect(header().string("Content-Type", "application/json"))
+                    .andExpect(header().string("Cache-Control", "max-age=" + LocalAuthorityController.MAX_AGE_SECONDS));
+        }
     }
 
 }

--- a/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/RatingsTest.java
+++ b/src/test/java/uk/me/jeremygreen/springexperiments/fsa/api/RatingsTest.java
@@ -1,0 +1,52 @@
+package uk.me.jeremygreen.springexperiments.fsa.api;
+
+import org.junit.Test;
+import uk.me.jeremygreen.springexperiments.fsa.FsaRating;
+import uk.me.jeremygreen.springexperiments.fsa.FsaRatings;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+public class RatingsTest {
+
+    @Test
+    public final void createInstance_emptyList() {
+        final FsaRatings fsaRatings = new FsaRatings(List.of());
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        assertEquals(List.of(), ratings.getRatings());
+    }
+
+    @Test
+    public final void createInstance_string() {
+        final List<String> ratingsList = List.of("xyz");
+        final FsaRatings fsaRatings = new FsaRatings(ratingsList.stream().map((rating) -> new FsaRating(rating)).toList());
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        assertEquals(ratingsList, ratings.getRatings());
+    }
+
+    @Test
+    public final void createInstance_0() {
+        final List<String> ratingsList = List.of("0");
+        final FsaRatings fsaRatings = new FsaRatings(ratingsList.stream().map((rating) -> new FsaRating(rating)).toList());
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        assertEquals(List.of("0-star"), ratings.getRatings());
+    }
+
+    @Test
+    public final void createInstance_strings_and_numbers() {
+        final List<String> ratingsList = List.of("x", "0", "1", "2", "5", "6", "10", "09234234");
+        final FsaRatings fsaRatings = new FsaRatings(ratingsList.stream().map((rating) -> new FsaRating(rating)).toList());
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        assertEquals(List.of("x", "0-star", "1-star", "2-star", "5-star", "6-star", "10-star", "09234234-star"), ratings.getRatings());
+    }
+
+    @Test
+    public final void createInstance_already_star_suffix() {
+        final List<String> ratingsList = List.of("1-star");
+        final FsaRatings fsaRatings = new FsaRatings(ratingsList.stream().map((rating) -> new FsaRating(rating)).toList());
+        final Ratings ratings = Ratings.createInstance(fsaRatings);
+        assertEquals(ratingsList, ratings.getRatings());
+    }
+
+}


### PR DESCRIPTION
Adds https://api.ratings.food.gov.uk/Help/Api/GET-Ratings to the server, under /api/fsa/ratings. Need to map 0, 1, 2,... etc. to 0-star etc.

Showing all ratings improves the animations between local authorities.

Right aligning text in table means the percentage symbols line up, which looks nicer. Had to redo the (strange) bar graph implementation to make this work.